### PR TITLE
human-readable URLs with conference slug

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -47,7 +47,7 @@ class Admin::ConferencesController < Admin::ApplicationController
   private
 
   def set_conference
-    @conference = Conference.find(params[:id])
+    @conference = Conference.find_by!(slug: params[:slug])
   end
 
   def conference_params

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -53,6 +53,7 @@ class Admin::ConferencesController < Admin::ApplicationController
   def conference_params
     params.require(:conference).permit(
       :name,
+      :slug,
       :application_opens_at,
       :application_closes_at,
       :amendment_closes_at,

--- a/app/controllers/admin/form_descriptions_controller.rb
+++ b/app/controllers/admin/form_descriptions_controller.rb
@@ -48,7 +48,7 @@ class Admin::FormDescriptionsController < Admin::ApplicationController
   end
 
   def set_conference
-    @conference = Conference.find(params[:conference_id])
+    @conference = Conference.find_by!(slug: params[:conference_slug])
   end
 
   def set_form_description

--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -48,7 +48,7 @@ class Admin::PlansController < Admin::ApplicationController
   end
 
   def set_conference
-    @conference = Conference.find(params[:conference_id])
+    @conference = Conference.find_by!(slug: params[:conference_slug])
   end
 
   def set_plan

--- a/app/controllers/sponsorship_asset_files_controller.rb
+++ b/app/controllers/sponsorship_asset_files_controller.rb
@@ -1,7 +1,7 @@
 class SponsorshipAssetFilesController < ApplicationController
   def create
     return render(status: 403, json: {error: 403}) if current_sponsorship&.asset_file
-    conference = Conference.find(params[:conference_id])
+    conference = Conference.find_by!(slug: params[:conference_slug])
     return render(status: 403, json: {error: 403}) if !conference&.amendment_open? && !current_staff
 
     asset_file = SponsorshipAssetFile.create!(prefix: "#{conference.id}/", extension: params[:extension])

--- a/app/controllers/sponsorships_controller.rb
+++ b/app/controllers/sponsorships_controller.rb
@@ -19,7 +19,7 @@ class SponsorshipsController < ApplicationController
   def new
     return render(status: 404, plain: '404') if current_sponsorship
 
-    @conference = Conference.find(params[:conference_id])
+    @conference = Conference.find_by!(slug: params[:conference_slug])
     return render(:closed, status: 403) if !@conference&.application_open? && !current_staff
 
     @sponsorship = Sponsorship.new(conference: @conference)
@@ -29,7 +29,7 @@ class SponsorshipsController < ApplicationController
   def create
     return render(status: 404, plain: '404') if current_sponsorship
 
-    @conference = Conference.find(params[:conference_id])
+    @conference = Conference.find_by!(slug: params[:conference_slug])
     return render(:closed, status: 403) if !@conference&.application_open? && !current_staff
 
     @sponsorship = Sponsorship.new(sponsorship_params)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -10,6 +10,8 @@ class Conference < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
   validates :contact_email_address, presence: true
 
+  before_validation :generate_slug
+
   def application_open?
     t = Time.now
     application_opens_at && application_opens_at <= t && (!application_closes_at || t < application_closes_at)
@@ -22,5 +24,9 @@ class Conference < ApplicationRecord
 
   def form_description_for_locale
     form_descriptions.find_by(locale: I18n.locale) || form_descriptions.find_by!(locale: 'en')
+  end
+
+  private def generate_slug
+    self.slug = name.remove(' ').parameterize if slug.blank?
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -12,6 +12,10 @@ class Conference < ApplicationRecord
 
   before_validation :generate_slug
 
+  def to_param
+    slug
+  end
+
   def application_open?
     t = Time.now
     application_opens_at && application_opens_at <= t && (!application_closes_at || t < application_closes_at)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -7,6 +7,7 @@ class Conference < ApplicationRecord
   scope :amendment_open, -> { t = Time.now; where('application_opens_at <= ? AND (amendment_closes_at > ? OR amendment_closes_at IS NULL) AND application_opens_at IS NOT NULL', t, t) }
 
   validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true
   validates :contact_email_address, presence: true
 
   def application_open?

--- a/app/views/admin/conferences/_form.html.haml
+++ b/app/views/admin/conferences/_form.html.haml
@@ -9,6 +9,9 @@
     = form.label :name
     = form.text_field :name, class: 'form-control', required: true
   .form-group
+    = form.label :slug
+    = form.text_field :slug, class: 'form-control', required: true
+  .form-group
     = form.label :contact_email_address
     = form.email_field :contact_email_address, class: 'form-control', required: true
 

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -2,6 +2,9 @@
   %strong Name:
   = @conference.name
 %p
+  %strong Slug:
+  = @conference.slug
+%p
   %strong Application opens:
   = @conference.application_opens_at
   til

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   scope path: 'admin', module: 'admin' do
     get '/' => 'dashboard#index', as: :dashboard
-    resources :conferences do
+    resources :conferences, param: :slug do
       resources :form_descriptions, except: %i(index)
       resources :plans, except: %i(index show)
       resources :sponsorships, except: %i(index new create destroy) do
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
       get 'claim/:handle', action: :claim, as: :claim
     end
 
-    resources :conferences, only: %i(index) do
+    resources :conferences, param: :slug, only: %i(index) do
       resource :sponsorship, only: %i(new create show edit update)
       resource :sponsorship_asset_file, only: %i(create update)
     end

--- a/db/migrate/20181129211812_add_slug_to_conferences.rb
+++ b/db/migrate/20181129211812_add_slug_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddSlugToConferences < ActiveRecord::Migration[5.2]
+  def change
+    add_column :conferences, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_11_224714) do
+ActiveRecord::Schema.define(version: 2018_11_29_211812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2018_11_11_224714) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "contact_email_address"
+    t.string "slug"
     t.index ["application_opens_at"], name: "index_conferences_on_application_opens_at"
   end
 


### PR DESCRIPTION
なんかURLが /conferences/2/... ってなるのが微妙な感じだったので、以下のようになるようにしてみました。どんなもんでしょうか？

<img width="230" alt="rubykaigi2019_slug" src="https://user-images.githubusercontent.com/11493/49260105-6954f700-f47f-11e8-9691-256c0512a4c9.png">

実装としては、Conference に slug っていうStringなカラムを追加して、その文字列をURLに出すようにする、っていう感じです。
本番環境の既存レコードには slug が入っていないので登録してやる必要があって、そこで `before_validation` とかいう微妙すぎるタイミングでそれっぽいものを勝手に生成する便利機能が入ってるので、一度 admin の編集画面から conferences/2 を edit して update してやる必要があります。