### PR TITLE
Redirect the users to the default conference if determinable

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,5 +1,9 @@
 class ConferencesController < ApplicationController
   def index
     @conferences = Conference.application_open.order(id: :asc)
+
+    if @conferences.one?
+      redirect_to user_conference_sponsorship_path(@conferences.first)
+    end
   end
 end


### PR DESCRIPTION
本番環境では複数年のConferenceのスポンサーを同時に募集することは無いはずなので、現在募集中のConferenceが1つに定まる場合、いちいちユーザーにクリックさせる手間を省いていきなりそいつの応募フォームが開くようにしました。

ちょっと唐突感があるかもしれないけど、去年までもそうだったのでまぁそんなもんじゃないでしょうか。