### PR TITLE
Sort plans by rank

### DIFF
--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -39,7 +39,7 @@
 
 %h4 Sponsorships
 
-- @conference.sponsorships.group_by(&:plan).each do |plan, sponsorships|
+- @conference.sponsorships.group_by(&:plan).sort_by {|p, _| p&.rank || 9999 }.each do |plan, sponsorships|
   %h5= plan&.name || 'Undetermined'
   %ul
     - sponsorships.each do |sponsorship|


### PR DESCRIPTION
https://sponsorships.rubykaigi.org/admin/conferences/rubykaigi2019 を見るとなんか並び順がアレなので、雑にアレするパッチです。