### PR TITLE
admin/conferences: show summary (num/capacity) of plans

### DIFF
--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -40,8 +40,10 @@
         Plans
       .card-body
         %ul
-          - @conference.plans.order(rank: :desc).select(:id, :name).each do |plan|
-            %li= link_to plan.name, edit_conference_plan_path(@conference, plan)
+          - @conference.plans.order(rank: :desc).select(:id, :name, :capacity).each do |plan|
+            %li
+              = link_to plan.name, edit_conference_plan_path(@conference, plan)
+              %span (#{plan&.sponsorships&.size}/#{plan&.capacity})
         = link_to 'Add plan', new_conference_plan_path(@conference), class: 'card-link'
 
   .col-md-4


### PR DESCRIPTION
スポンサーの状況を確認する際、管理画面でPlansのところを見るだけで各プランのスポンサー数が分かるようにしたいのですが、こんな感じでどうでしょうか？