### PR TITLE
Hide billing information from sponsorship form

### DIFF
--- a/app/views/sponsorships/_free-plan-form.html.haml
+++ b/app/views/sponsorships/_free-plan-form.html.haml
@@ -1,0 +1,170 @@
+- conference = sponsorship.conference
+- desc = conference.form_description_for_locale
+= form_with(model: sponsorship, url: user_conference_sponsorship_path(conference), local: true, class: 'sponsorships_form') do |form|
+  = hidden_field_tag :invite_code, params[:invite_code]
+
+  - if sponsorship.errors.any?
+    - I18n.with_options(scope: %i(errors template)) do |lo|
+      .alert.alert-danger
+        %p= lo.t :header, count: sponsorship.errors.count, model: sponsorship.class.name
+        %ul
+          - sponsorship.errors.full_messages.each do |message|
+            %li= message
+
+  %section.py-2
+    .form-group
+      %h2= t('.header', name: conference.name)
+      = desc.head_html&.html_safe
+
+  - if !sponsorship.persisted? && current_available_sponsorships
+    %section.py-3
+      .card
+        %h5.card-header
+          = t('.copy.header')
+        .card-body
+          %p.card-text= t('.copy.explanation')
+          .form-group
+            = select_tag "sponsorship_id_to_copy", options_for_select(current_available_sponsorships.map {|_| [_.conference.name, _.id] }, params[:sponsorship_id_to_copy]), class: 'form-control form-control-sm sponsorship_id_to_copy_selector', include_blank: true
+
+  %section.py-2
+    .form-group
+      %h3= t('.contact')
+
+    = form.fields_for :contact do |contact_form|
+      .form-group
+        = contact_form.label :email
+        = contact_form.email_field :email, class: 'form-control', required: true
+
+      .form-group
+        = contact_form.label :email_cc
+        = contact_form.text_field :email_cc, class: 'form-control', placeholder: 'cc1@example.com, cc2@example.com, ... (optional)'
+        %small.form-text= t('.email_cc_help')
+
+      .form-group
+        = contact_form.label :address
+        = contact_form.text_field :address, class: 'form-control', required: true
+
+      .form-group
+        = contact_form.label :organization
+        = contact_form.text_field :organization, class: 'form-control', required: true
+
+      .form-group
+        = contact_form.label :unit
+        = contact_form.text_field :unit, class: 'form-control', placeholder: t('.optional')
+
+      .form-group
+        = contact_form.label :name
+        = contact_form.text_field :name, class: 'form-control', required: true
+
+  %section.py-2
+    .form-group
+      %h3= t('.plan')
+      = desc.plan_help_html&.html_safe
+
+    %fieldset{disabled: @sponsorship.accepted?}
+      .form-group.sponsorships_form_plans
+        %h5= t('.plans')
+        - conference.plans.each do |plan|
+          .form-check
+            %label.form-check-label
+              = form.radio_button :plan_id, plan.id, checked: 'checked', class: 'form-check-input', disabled: !plan.available? && plan.id != @sponsorship.plan_id, data: {booth: plan.booth_eligible? ? '1' : '0', words_limit_help: t('.plan_explanation.words_limit', count: plan.words_limit), acceptance_help: plan.auto_acceptance ? t('.plan_explanation.auto_acceptance', plan: plan.name) : t('.plan_explanation.not_auto_acceptance', plan: plan.name), guests: plan.number_of_guests}
+              = plan.name
+              - case
+              - when plan.sold_out?
+                %small.badge.badge-danger= t('.plan_sold_out')
+              - when plan.closed?
+                %small.badge.badge-danger= t('.plan_closed')
+
+  %section.py-2{class: @conference.booth_capacity > 0 ? '' : 'd-none'}
+    .form-group
+      %h3= t('.booth')
+      = desc.booth_help_html&.html_safe
+
+    .form-group.sponsorships_form_booth_request
+      .form-check
+        = form.check_box :booth_requested, class: 'form-check-input'
+        = form.label :booth_requested, class: 'form-check-label'
+      %small.d-none.sponsorships_form_booth_request_uneligible.form-text.text-small.text-info= t('.booth_uneligible_plan_selected', plans: conference.plans.select(&:booth_eligible?).map(&:name).join(', '))
+
+  %section.py-2
+    .form-group
+      %h3= t('.information')
+
+      %p= t('.information_help')
+
+    .form-group
+      = form.label :name
+      = form.text_field :name, class: 'form-control', required: true
+
+    .form-group
+      = form.label :url
+      = form.text_field :url, class: 'form-control', required: true, placeholder: 'https://...'
+
+    .form-group
+      = form.label :profile
+      = form.text_area :profile, class: 'form-control', required: true
+      %small.sponsorships_form_profile_help.form-text
+
+  %section.py-2
+    .form-group
+      %h3= t('.logo')
+
+      %p= t('.logo_help')
+
+    .form-group.sponsorships_form_asset_file{data: {session_endpoint: user_conference_sponsorship_asset_file_path, session_endpoint_method: sponsorship.asset_file&.persisted? ? 'PUT': 'POST'}}
+      = form.hidden_field :asset_file_id
+      = form.hidden_field :asset_file_id_to_copy unless sponsorship.persisted?
+      .sponsorships_form_asset_file_form (Loading)
+
+    - if sponsorship.persisted? && sponsorship.asset_file
+      %small.form-text= link_to t('.download_logo'), user_conference_sponsorship_asset_file_path
+
+  - if conference.additional_attendees_registration_open
+    %section.py-2.sponsorships_form_tickets
+      .form-group
+        %h3= t('.tickets')
+
+        = desc.ticket_help_html&.html_safe
+
+      .form-group.row
+        .col-sm-5.text-sm-right
+          %label= t('.tickets_included_in_plan')
+        .col-sm-7
+          .sponsorships_form_tickets__included_in_plan{style: 'padding-left: 0.75rem;'} -
+      .form-group.row
+        .col-sm-5.text-sm-right
+          = form.label :number_of_additional_attendees, t('.tickets_additionally_request')
+        .col-sm-7.sponsorships_form_tickets__additional_attendees
+          = form.number_field :number_of_additional_attendees, class: 'form-control', min: 0
+      .form-group.row
+        .col-sm-5.text-sm-right
+          %label= t('.tickets_total')
+        .col-sm-7
+          .sponsorships_form_tickets__total{style: 'padding-left: 0.75rem;'} -
+
+  %section.py-2
+    .form-group
+      %h3= t('.note')
+
+      %p= t('.others_help')
+
+    = form.fields_for :note do |request_form|
+      .form-group
+        = request_form.label :body
+        = request_form.text_area :body, class: 'form-control'
+
+  %section.py-2
+    .form-group
+      %h3= t('.policies')
+
+      %p= desc.policy_help_html&.html_safe
+
+      .form-check
+        = form.check_box :policy_agreement, class: 'form-check-input', required: true
+        = form.label :policy_agreement, "", class: 'form-check-label'
+
+    .form-group
+      = form.submit t('.submit'), class: 'btn btn-primary', data: {disable_with: false}
+      %small.form-text.sponsorships_acceptance_help
+
+    .alert.alert-danger.submit_error.d-none

--- a/app/views/sponsorships/edit.html.haml
+++ b/app/views/sponsorships/edit.html.haml
@@ -1,4 +1,7 @@
 - if @conference.amendment_closes_at
   %p= t('.amendment_availability', ts: l(@conference.amendment_closes_at))
 
-= render 'form', sponsorship: @sponsorship
+- if @conference.allow_restricted_access
+  = render 'free-plan-form', sponsorship: @sponsorship
+- else
+  = render 'form', sponsorship: @sponsorship

--- a/app/views/sponsorships/new.html.haml
+++ b/app/views/sponsorships/new.html.haml
@@ -6,4 +6,7 @@
     %br
     Application opens at: #{l(@conference.application_opens_at)}
 
-= render 'form', sponsorship: @sponsorship
+- if @conference.allow_restricted_access
+  = render 'free-plan-form', sponsorship: @sponsorship
+- else
+  = render 'form', sponsorship: @sponsorship

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -97,7 +97,7 @@ ja:
 
 
   sponsorships:
-    form:
+    form: &form
       optional: '(任意)'
       header: '%{name} スポンサーシップ申込フォーム'
       copy:
@@ -147,6 +147,7 @@ ja:
       note: 'その他の連絡事項'
       policies: 'ポリシー'
       submit: '送信'
+    free-plan-form: *form
     closed:
       header: '申し込み期間ではありません'
       closed: "スポンサーシップのお申し込みをご検討いただきありがとうございます。申し訳ありませんが、本イベントへのスポンサー申し込みは %{ts} に締め切られました。"
@@ -225,4 +226,3 @@ ja:
       guide2: "このチケットを再表示するためのリンクは記入されたメールアドレスへ送信されています。"
       reissue_guide: "複数登録する場合、また記入ミスがあった場合のチケットの再登録は"
       reissue_link: "こちらから可能です。"
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,6 +257,7 @@ ActiveRecord::Schema.define(version: 2020_08_26_203120) do
     t.string "ticket_key", null: false
     t.datetime "accepted_at"
     t.index ["conference_id", "organization_id"], name: "index_sponsorships_on_conference_id_and_organization_id", unique: true
+    t.index ["conference_id", "ticket_key"], name: "index_sponsorships_on_conference_id_and_ticket_key", unique: true
     t.index ["conference_id"], name: "index_sponsorships_on_conference_id"
     t.index ["organization_id"], name: "index_sponsorships_on_organization_id"
     t.index ["plan_id"], name: "index_sponsorships_on_plan_id"


### PR DESCRIPTION
Kaigi on Rails STAY HOME EditionのスポンサーはRubyKaigi Takeout 2020のスポンサーに申し込んでくださった企業様のみ案内。
追加の支払いが不要なこともあり、混乱を招かないよう主に請求系の入力欄を隠すためのプルリク。

そういう機能自体作っちゃってもいいかと思ったのですが、今後特に使い道もなさそうなので一時的な対応。
（意味が合わないのですが `Conference#allow_restricted_access` を使ってしまいました 🙏 ）

別partialを追加したのは、なんとなく元ファイルをあまり汚したくなかったので。

<img width="569" alt="スクリーンショット 2020-09-02 23 50 05" src="https://user-images.githubusercontent.com/3654953/91999178-10627300-ed77-11ea-9ddb-d4f793ecbe65.png">

### Diff from form
```diff
-  %section.py-2.sponsorships_form_billing_contact
-    .form-group
-      %h3= t('.billing')
-
-    = form.fields_for :alternate_billing_contact do |contact_form|
-      .form-group
-        .form-check
-          = contact_form.check_box :_keep, class: 'form-check-input'
-          = contact_form.label :_keep, t('.specify_alternate_billing_contact'), class: 'form-check-label'
-
-      %fieldset
-        .form-group
-          = contact_form.label :email
-          = contact_form.email_field :email, class: 'form-control', required: true
-
-        .form-group
-          = contact_form.label :address
-          = contact_form.text_field :address, class: 'form-control', required: true
-
-        .form-group
-          = contact_form.label :organization
-          = contact_form.text_field :organization, class: 'form-control', required: true
-
-        .form-group
-          = contact_form.label :unit
-          = contact_form.text_field :unit, class: 'form-control', placeholder: t('.optional')
-
-        .form-group
-          = contact_form.label :name
-          = contact_form.text_field :name, class: 'form-control', required: true
-
-    = form.fields_for :billing_request do |request_form|
-      .form-group
-        = request_form.label :body
-        = request_form.text_area :body, class: 'form-control', aria: {describedby: 'billing_request_help'}
-        %small.form-text#billing_request_help= t('.billing_request_help')
-
   %section.py-2
     .form-group
       %h3= t('.plan')
@@ -104,32 +67,14 @@
         - conference.plans.each do |plan|
           .form-check
             %label.form-check-label
-              = form.radio_button :plan_id, plan.id, checked: plan.id == @sponsorship.plan_id, class: 'form-check-input', disabled: !plan.available? && plan.id != @sponsorship.plan_id, data: {booth: plan.booth_eligible? ? '1' : '0', words_limit_help: t('.plan_explanation.words_limit', count: plan.words_limit), acceptance_help: plan.auto_acceptance ? t('.plan_explanation.auto_acceptance', plan: plan.name) : t('.plan_explanation.not_auto_acceptance', plan: plan.name), guests: plan.number_of_guests}
+              = form.radio_button :plan_id, plan.id, checked: 'checked', class: 'form-check-input', disabled: !plan.available? && plan.id != @sponsorship.plan_id, data: {booth: plan.booth_eligible? ? '1' : '0', words_limit_help: t('.plan_explanation.words_limit', count: plan.words_limit), acceptance_help: plan.auto_acceptance ? t('.plan_explanation.auto_acceptance', plan: plan.name) : t('.plan_explanation.not_auto_acceptance', plan: plan.name), guests: plan.number_of_guests}
               = plan.name
-              %small<
-                #{plan.price_text}
-                , #{t('.plan_explanation.guests', count: plan.number_of_guests)}
-                - if plan.booth_eligible?
-                  , #{t('.plan_explanation.booth', count: plan.booth_size)}
-                - if plan.talkable?
-                  , #{t('.plan_explanation.talk')}
               - case
               - when plan.sold_out?
                 %small.badge.badge-danger= t('.plan_sold_out')
               - when plan.closed?
                 %small.badge.badge-danger= t('.plan_closed')
 
-        - if @conference.no_plan_allowed || (@sponsorship.persisted? && @sponsorship.plan_id == nil)
-          .form-check
-            %label.form-check-label
-              = form.radio_button :plan_id, '', checked: @sponsorship.plan_id == nil && (@sponsorship.persisted? || @sponsorship.errors.any?), class: 'form-check-input', data: {other: '1', guests: 0}
-              Other
-
-    = form.fields_for :customization_request do |request_form|
-      .form-group
-        = request_form.label :body
-        = request_form.text_area :body, class: 'form-control sponsorships_form_customization_request'
-

```

## 今後
このプルリク指定でデプロイしてもいいし、一旦取り込んでスポンサー募集期間が終わったら元に戻す変更をしてもいいし、どちらでも楽な方で！