### PR TITLE
Takeout 2021 のカラースキームに変更

### DIFF
--- a/app/stylesheets/styles/config/_base.sass
+++ b/app/stylesheets/styles/config/_base.sass
@@ -1,14 +1,14 @@
 body
   color: $default-text
-  background-color: $lightpink
+  background-color: $base-bg
   min-height: 100vh
   font-size: 100%
 
 a
-  color: $black
+  color: $link
   &:hover,
   &:focus
-    color: lighten($black, 10%)
+    color: $link-hover
 
 img
   max-width: 100%
@@ -17,28 +17,32 @@ small
   font-size: 70%
 
 nav.navbar.navbar-expand-lg.navbar-dark
-  background-color: lighten($vividpink, 30%)
+  background-color: $nav-bg
+  box-shadow: $nav-shadow
 
 nav.navbar.navbar-expand-lg a,
 nav.navbar.navbar-expand-lg a.dropdown-item,
 .navbar-dark .navbar-nav .nav-link
-  color: $black
+  color: $nav-link
   &:hover,
   &:focus
-    color: $grey
+    color: $nav-link-hover
 
 nav.navbar.navbar-expand-lg a.dropdown-item
 .navbar-dark .navbar-nav .show > .nav-link
-  color: $black
+  color: $nav-link
+
+.navbar-dark .navbar-toggler
+  border-color: $nav-toggler-border
 
 .navbar-toggler .navbar-toggler-icon
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(0,0,0,1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E")
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(11,55,77,1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E")
 
 .btn-primary
-  background-color: $vividpink
-  border-color: darken($vividpink, 10%)
+  background-color: $btn-primary-bg
+  border-color: $btn-primary-border
 
 .btn-primary
   &:hover
-    background-color: darken($vividpink, 10%)
-    border-color: darken($vividpink, 20%)
+    background-color: $btn-primary-bg-hover
+    border-color: $btn-primary-border-hover

--- a/app/stylesheets/styles/config/_variables.sass
+++ b/app/stylesheets/styles/config/_variables.sass
@@ -3,27 +3,44 @@ $media-breakpoints: (xs: 0, se: 320px, sm: 576px, md: 768px, lg: 1024px, xl: 140
 
 // colors
 $black: #1e3549
-$lightpink: #fff8fb
 $white: #fff
-$blue: #00b9d5
-$grey: #585959
 $whitegrey: #A9A9A9
-$vividpink: #d84c85
 
+$color-base: #EBE0CE
+$color-main: #0B374D
+$color-main-light: #545F64
+$color-accent: #E14033
+
+// background-color
+$base-bg: $color-base
 
 // text-colors
-$default-text: $black
-$reversal-text: $black
-$muted-text: #77766a
+$default-text: $color-main
+$reversal-text: $color-main
+$muted-text: $color-main-light
 
-$link: #ff5850
+$link: #127CAE
+$link-hover: #0092D8
 
-$border: $lightpink
+$border: $color-main-light
 
 // bland-colors
-$base-color: $lightpink
-$accent-color: $vividpink
-$accent-color-border: $vividpink
+$base-color: $color-base
+$accent-color: $color-accent
+$accent-color-border: $color-accent
+
+// navbar
+$nav-link: $color-main
+$nav-link-hover: $color-main-light
+$nav-bg: $color-base
+$nav-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15)
+$nav-toggler-border: transparent
+
+// button
+$btn-primary-bg: $color-accent
+$btn-primary-border: transparent
+$btn-primary-bg-hover: darken($color-accent, 10%)
+$btn-primary-border-hover: transparent
 
 // schedule
 $break: #e0e0cf


### PR DESCRIPTION
### やったこと
- Takeout 2021 のカラーに変更
- _base.sass の変数名を汎用的なものにして、今後色を変更する時 variables.sass だけを編集すればよくなるように調整

### 確認したいこと
- ~~ロゴを変更するという話がありましたが、どこの部分を指していますか？~~
- 変更が漏れている箇所はありますか？


### キャプチャ

![貼り付けた画像_2021_04_28_20_44](https://user-images.githubusercontent.com/4459676/116398241-89608e80-a862-11eb-8c26-93f232acc5ab.jpg)

![貼り付けた画像_2021_04_28_20_45](https://user-images.githubusercontent.com/4459676/116398363-ac8b3e00-a862-11eb-90f5-02f0d1cc8500.jpg)