### PR TITLE
Update README (webpacker retired)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 rails s
-./bin/webpack --watch
+yarn run watch
 ```
 
 - http://localhost:3000/


### PR DESCRIPTION
The app use simpacker from d7b496303 , webpacker removed.
And "yarn run build" introduced at 1c22230b5