### PR TITLE
背景色を2025用に変更

### DIFF
--- a/app/stylesheets/styles/config/_variables.sass
+++ b/app/stylesheets/styles/config/_variables.sass
@@ -6,7 +6,7 @@ $black: #000
 $white: #FFF
 $whitegrey: #A9A9A9
 
-$color-base: #FFFEF4
+$color-base: #FFF5EC
 $color-main: $black
 $color-main-light: #7B7B7B
 $color-accent: #000


### PR DESCRIPTION
背景色を `#FFFEF4` から `#FFF5EC` に変更しました
他は既存のままでよさそうです

![スクリーンショット 2024-11-13 12 13 52](https://github.com/user-attachments/assets/ac159476-2dda-4711-9f27-6af8e57b405d)


issue
https://github.com/ruby-no-kai/rubykaigi.org/issues/2584
