### PR TITLE
Plan#sold_out?: Properly respect Plan capacity

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -15,7 +15,7 @@ class Plan < ApplicationRecord
   end
 
   def sold_out?
-    !capacity || sponsorships.active.count > capacity
+    !capacity || sponsorships.active.count >= capacity
   end
 
   def closed?(t = Time.zone.now)


### PR DESCRIPTION
`Plan`s should allow `Sponsorship`s up to `capacity`.