### PR TITLE
Booth Assignment: show number of requests from accepted and unaccepted sponsors

### DIFF
--- a/app/controllers/admin/booth_assignments_controller.rb
+++ b/app/controllers/admin/booth_assignments_controller.rb
@@ -2,6 +2,11 @@ class Admin::BoothAssignmentsController < ::Admin::ApplicationController
   before_action :set_conference
 
   def show
+    @not_withdrawn_sponsorships = @conference.sponsorships
+      .includes(:plan)
+      .not_withdrawn
+      .where(booth_requested: true)
+      .order('plans.booth_size desc, sponsorships.name asc')
     @sponsorships = @conference.sponsorships
       .includes(:plan)
       .active

--- a/app/views/admin/booth_assignments/show.html.haml
+++ b/app/views/admin/booth_assignments/show.html.haml
@@ -8,7 +8,7 @@
 
 %section
   %p
-    Booth requested: #{@sponsorships.size} sponsors (capacity #{@sponsorships.map(&:booth_size).compact.inject(:+)})
+    Booth requested: #{@sponsorships.size} sponsors (capacity #{@sponsorships.map(&:booth_size).compact.inject(:+)}) (including non accepted sponsors: #{@not_withdrawn_sponsorships.size})
     %br
     Booth assigned: #{@exhibitors.size} sponsors (capacity #{@exhibitors.map(&:assigned_booth_size).compact.inject(:+)})
 


### PR DESCRIPTION
ブースのリクエスト数がacceptするまで分からないようだったので、withdrawnしたスポンサー以外で集計した数も表示したいです。

#90 のseedを入れた状態だと（リクエストがあったスポンサーはacceptされてないので）下記のようになります。

<img width="692" alt="booth" src="https://github.com/user-attachments/assets/f93544dc-67ec-4399-9fbf-239a5b6c1a04" />
