### PR TITLE
Allow hyphenated words and contractions to be counted as single words

### DIFF
--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -146,7 +146,7 @@ class Sponsorship < ApplicationRecord
   end
 
   def word_count
-    profile&.scan(/\w+/)&.size || 0
+    profile&.scan(/[\w\-']+/)&.size || 0
   end
 
   def policy_agreement


### PR DESCRIPTION
I consider it more natural to count "It's" as a single word rather than two words.

e.g.,

```
irb(main):001> "He's my father-in-law.".scan(/\w+/).size
=> 6
irb(main):002> "He's my father-in-law.".scan(/[\w\-']+/).size
=> 3
```
