### PR TITLE
Count words with punctuation apostrophes considered

### DIFF
--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -146,7 +146,7 @@ class Sponsorship < ApplicationRecord
   end
 
   def word_count
-    profile&.scan(/[\w\-']+/)&.size || 0
+    profile&.scan(/[\w\-'’]+/)&.size || 0
   end
 
   def policy_agreement


### PR DESCRIPTION
This is a follow-up of <https://github.com/ruby-no-kai/sponsor-app/pull/92>.

I found that Unicode suggests using U+2019 `’` for punctuation instead of U+0027 `'`: <https://en.wikipedia.org/wiki/Apostrophe#Unicode>. For example, Google Docs automatically converts `He's` to `He’s`.

So this patch adds support for U+2019 in addition to U+0027 in Sponsorship#word_count.