### PR TITLE
fix: Capitalize plan names in fallback options for human

### DIFF
--- a/misc/fallback_options.libsonnet
+++ b/misc/fallback_options.libsonnet
@@ -41,7 +41,7 @@
     conditions: [
       { plans: ['Platinum'], booth_request: true },
     ],
-    priority_human: ['{plan}!no_booth', 'gold'],
+    priority_human: ['{plan}!no_booth', 'Gold'],
   },
   {
     value: 'platinum+booth,platinum,silver',
@@ -52,7 +52,7 @@
     conditions: [
       { plans: ['Platinum'], booth_request: true },
     ],
-    priority_human: ['{plan}!no_booth', 'silver'],
+    priority_human: ['{plan}!no_booth', 'Silver'],
   },
   {
     value: 'platinum+booth,platinum',


### PR DESCRIPTION
Before | After
-- | --
<img width="1133" height="437" alt="スクリーンショット 2025-11-28 15 00 10" src="https://github.com/user-attachments/assets/4c12a871-e4ff-4cda-ac0a-fd59a4b56608" /> | <img width="1136" height="438" alt="スクリーンショット 2025-11-28 15 00 33" src="https://github.com/user-attachments/assets/256cd040-338f-4cbd-97e8-c730a49ebd60" />

^ The last line is not capitalized by the current seed configs.