### PR TITLE
allow overriding sponsorships.organization_id

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,5 +1,5 @@
 class Admin::OrganizationsController < Admin::ApplicationController
-  before_action :set_organization, except: [:index]
+  before_action :set_organization, except: %i[index new create]
 
   def index
     @organizations = Organization.all.order(:name)
@@ -7,6 +7,22 @@ class Admin::OrganizationsController < Admin::ApplicationController
 
   def show
     @sponsorships = @organization.sponsorships.includes(:conference, :plan).order(id: :desc)
+    @conferences_open_for_application = Conference.application_open.order(id: :desc)
+  end
+
+  def new
+    @organization = Organization.new
+  end
+
+  def create
+    @organization = Organization.new(organization_params)
+    respond_to do |format|
+      if @organization.save
+        format.html { redirect_to organization_path(@organization), notice: 'Organization was successfully created.' }
+      else
+        format.html { render :new }
+      end
+    end
   end
 
   def edit

--- a/app/controllers/sponsorships_controller.rb
+++ b/app/controllers/sponsorships_controller.rb
@@ -29,6 +29,8 @@ class SponsorshipsController < ApplicationController
     return render(plain: '404', status: 404) unless @conference.verify_invite_code(params[:invite_code])
     return render(:closed, status: 403) if !@conference&.application_open? && !current_staff
 
+    @affiliated_organization = Organization.find_by_affiliation_code(params[:affiliation])
+
     @sponsorship = Sponsorship.new(copied_sponsorship_attributes)
     @sponsorship.conference = @conference
     @sponsorship.build_nested_attributes_associations
@@ -63,7 +65,8 @@ class SponsorshipsController < ApplicationController
 
     @sponsorship.locale = I18n.locale
     @sponsorship.conference = @conference
-    @sponsorship.assume_organization
+    affiliated_organization = Organization.find_by_affiliation_code(params[:affiliation])
+    @sponsorship.assume_organization(affiliated_organization:)
     @sponsorship.accept if @sponsorship.plan&.auto_acceptance && !@sponsorship.organization&.auto_acceptance_disabled
 
     respond_to do |format|

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,7 +1,10 @@
 class Organization < ApplicationRecord
+  attribute :affiliation_code, :string, default: -> { SecureRandom.urlsafe_base64(24) }
+
   has_many :sponsorships
   validates :name, presence: true
   validates :domain, presence: true
+  validates :affiliation_code, presence: true, uniqueness: true
 
   def slug
     domain
@@ -9,5 +12,18 @@ class Organization < ApplicationRecord
 
   def to_param
     domain
+  end
+
+  def self.find_by_affiliation_code(code)
+    return nil if code.blank?
+    find_by(affiliation_code: code)
+  end
+
+  def affiliation_url(conference)
+    Rails.application.routes.url_helpers.new_user_conference_sponsorship_url(
+      conference_slug: conference.slug,
+      affiliation: affiliation_code,
+      host: Rails.application.config.action_mailer.default_url_options&.fetch(:host) || 'localhost:3000'
+    )
   end
 end

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -164,8 +164,12 @@ class Sponsorship < ApplicationRecord
     alternate_billing_contact || contact
   end
 
-  def assume_organization
-    self.organization = Organization.create_with(name: self.name).find_or_initialize_by(domain: self.contact&.email&.split(?@, 2)&.last&.downcase)
+  def assume_organization(affiliated_organization: nil)
+    if affiliated_organization
+      self.organization = affiliated_organization
+    else
+      self.organization = Organization.create_with(name: self.name).find_or_initialize_by(domain: self.contact&.email&.split(?@, 2)&.last&.downcase)
+    end
   end
 
   def to_h_for_history

--- a/app/views/admin/organizations/index.html.haml
+++ b/app/views/admin/organizations/index.html.haml
@@ -5,7 +5,10 @@
     %li.breadcrumb-item= link_to 'Admin', dashboard_path
     %li.breadcrumb-item.active{aria: {current: 'page'}} Organizations
 
-%h1 Organizations
+.d-md-flex.justify-content-between
+  %h1 Organizations
+  %div
+    = link_to "New Organization", new_organization_path, class: 'btn btn-primary'
 
 - if @organizations.empty?
   %p.text-muted No organizations yet

--- a/app/views/admin/organizations/new.html.haml
+++ b/app/views/admin/organizations/new.html.haml
@@ -1,0 +1,38 @@
+- content_for(:title) { t('.title') }
+
+%nav{aria: {label: 'breadcrumb'}}
+  %ol.breadcrumb
+    %li.breadcrumb-item= link_to 'Admin', dashboard_path
+    %li.breadcrumb-item= link_to 'Organizations', organizations_path
+    %li.breadcrumb-item.active{aria: {current: 'page'}} New
+
+%h1 New Organization
+
+= form_with(model: @organization, url: organizations_path, local: true) do |form|
+  - if @organization.errors.any?
+    .alert.alert-danger
+      %p #{pluralize(@organization.errors.count, "error")} prohibited this from being saved:
+      %ul
+        - @organization.errors.full_messages.each do |message|
+          %li= message
+
+  .form-group
+    = form.label :name
+    = form.text_field :name, class: 'form-control', required: true
+
+  .form-group
+    = form.label :domain
+    = form.text_field :domain, class: 'form-control', required: true
+    %small.form-text.text-muted
+      Email domain identifier (e.g., example.com)
+
+  .form-group
+    .form-check
+      = form.check_box :auto_acceptance_disabled, class: 'form-check-input'
+      = form.label :auto_acceptance_disabled, class: 'form-check-label'
+      %small.form-text.text-muted
+        When checked, sponsorships from this organization will not be auto-accepted even if the plan allows it
+
+  .form-group
+    = form.submit 'Create', class: 'btn btn-primary'
+    = link_to 'Cancel', organizations_path, class: 'btn btn-secondary'

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -32,6 +32,25 @@
                 %span.badge.badge-warning Disabled
               - else
                 %span.badge.badge-success Enabled
+          .row
+            %dt.col-sm-5 Affiliation Code
+            %dd.col-sm-7
+              %code= @organization.affiliation_code
+
+  .col-md-6
+    .card
+      %h5.card-header
+        Affiliation URLs
+      .card-body
+        %p.card-text.text-muted Share these URLs to allow sponsors to create multiple sponsorships under this organization.
+        - if @conferences_open_for_application.empty?
+          %p.text-muted No conferences are currently open for application.
+        - else
+          %ul.list-unstyled
+            - @conferences_open_for_application.each do |conference|
+              %li.mb-2
+                = link_to @organization.affiliation_url(conference), target: '_blank', rel: 'noopener' do
+                  = conference.name
 
 .row
   .col-md-12

--- a/app/views/sponsorships/_form.html.haml
+++ b/app/views/sponsorships/_form.html.haml
@@ -2,6 +2,11 @@
 - desc = conference.form_description_for_locale
 = form_with(model: sponsorship, url: user_conference_sponsorship_path(conference), local: true, class: 'sponsorships_form') do |form|
   = hidden_field_tag :invite_code, params[:invite_code]
+  = hidden_field_tag :affiliation, params[:affiliation]
+
+  - if @affiliated_organization
+    .alert.alert-info
+      = t('.affiliated_organization_notice', organization: @affiliated_organization.name)
 
   - if sponsorship.errors.any?
     - I18n.with_options(scope: %i(errors template)) do |lo|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
     form:
       optional: '(Optional)'
       header: '%{name} Sponsorship Application Form'
+      affiliated_organization_notice: 'This application will be affiliated with %{organization}.'
       copy:
         header: 'Filling the same information with your sponsorship application in past?'
         explanation: 'Select an existing application from below, then the existing data will be filled in.'
@@ -362,6 +363,8 @@ en:
         title: Organizations
       show:
         title: "%{organization}"
+      new:
+        title: New Organization
       edit:
         title: Edit Organization
     plans:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -102,6 +102,7 @@ ja:
     form:
       optional: '(任意)'
       header: '%{name} スポンサーシップ申込フォーム'
+      affiliated_organization_notice: 'このスポンサー申込は %{organization} に紐付けられます。'
       copy:
         header: '過去の申込情報を利用する'
         explanation: '過去の申込情報を利用することができます。下記より既存のスポンサーシップ申込を選択してください。'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :organizations, param: :slug, only: %i(index show edit update), constraints: {slug: /[^\/]+/}
+    resources :organizations, param: :slug, only: %i(index new create show edit update), constraints: {slug: /[^\/]+/}
 
     resource :session, only: %i(new destroy) do
       get :rise, as: :rise

--- a/db/migrate/20260121135127_add_affiliation_code_to_organizations.rb
+++ b/db/migrate/20260121135127_add_affiliation_code_to_organizations.rb
@@ -1,0 +1,6 @@
+class AddAffiliationCodeToOrganizations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :organizations, :affiliation_code, :string
+    add_index :organizations, :affiliation_code, unique: true, where: 'affiliation_code IS NOT NULL'
+  end
+end

--- a/db/migrate/20260121135759_populate_organization_affiliation_codes.rb
+++ b/db/migrate/20260121135759_populate_organization_affiliation_codes.rb
@@ -1,0 +1,15 @@
+require 'securerandom'
+
+class PopulateOrganizationAffiliationCodes < ActiveRecord::Migration[8.1]
+  def up
+    Organization.where(affiliation_code: nil).find_each do |org|
+      org.update_column(:affiliation_code, SecureRandom.urlsafe_base64(24))
+    end
+
+    change_column_null :organizations, :affiliation_code, false
+  end
+
+  def down
+    change_column_null :organizations, :affiliation_code, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_16_202113) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_21_135759) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -154,11 +154,13 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_16_202113) do
   end
 
   create_table "organizations", force: :cascade do |t|
+    t.string "affiliation_code", null: false
     t.boolean "auto_acceptance_disabled", default: false, null: false
     t.datetime "created_at", null: false
     t.string "domain", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.index ["affiliation_code"], name: "index_organizations_on_affiliation_code", unique: true, where: "(affiliation_code IS NOT NULL)"
     t.index ["domain"], name: "index_organizations_on_domain", unique: true
   end
 


### PR DESCRIPTION
generate organizations.affiliation_code, and giving it to sponsorships#new to override organization_id, which is default to be assumed based on email domain. this allows multiple applications from the single email domain.