### PR TITLE
ExpenseReportsController#create: avoid destroying existing report

### DIFF
--- a/app/controllers/expense_reports_controller.rb
+++ b/app/controllers/expense_reports_controller.rb
@@ -7,11 +7,13 @@ class ExpenseReportsController < ApplicationController
   before_action :set_expense_report, only: [:show, :update, :calculate]
 
   def create
-    begin
-      @expense_report = current_sponsorship.build_expense_report
-      @expense_report.save!
-    rescue ActiveRecord::RecordNotUnique
-      @expense_report = current_sponsorship.expense_report
+    @expense_report = current_sponsorship.expense_report
+    unless @expense_report
+      begin
+        @expense_report = ExpenseReport.create!(sponsorship: current_sponsorship)
+      rescue ActiveRecord::RecordNotUnique
+        @expense_report = current_sponsorship.reload_expense_report
+      end
     end
 
     respond_to do |format|

--- a/spec/requests/expense_reports_spec.rb
+++ b/spec/requests/expense_reports_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe "Expense Reports", type: :request do
       expect(sponsorship.expense_report.status).to eq('draft')
     end
 
+    context "when expense report already exists with line items" do
+      let!(:existing_report) { ExpenseReport.create!(sponsorship:) }
+      let!(:line_item) { FactoryBot.create(:expense_line_item, expense_report: existing_report, position: 1) }
+
+      it "preserves the existing report and its line items" do
+        original_id = existing_report.id
+
+        post user_conference_sponsorship_expense_report_path(conference)
+
+        expect(response).to redirect_to(user_conference_sponsorship_expense_report_path(conference))
+        expect(sponsorship.reload.expense_report.id).to eq(original_id)
+        expect(existing_report.reload.line_items).to eq([line_item])
+      end
+    end
+
     it "rejects non-custom sponsorships" do
       sponsorship.update_column(:customization, false) # rubocop:disable Rails/SkipsModelValidations
       post user_conference_sponsorship_expense_report_path(conference), as: :json


### PR DESCRIPTION
`build_expense_report` on a `has_one` with `dependent: :destroy` deletes the existing record (cascading to line_items and submissions) before inserting. The `RecordNotUnique` rescue never fires because the old row is already gone. Check for an existing report first, and use `ExpenseReport.create!` directly to bypass `has_one` replacement.