### PR TITLE
Allow build scripts for `@parcel/watcher` and esbuild

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -18,6 +18,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
+          node-version: '24.x'
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-COPY package.json pnpm-lock.yaml /app/
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 RUN pnpm install --frozen-lockfile
 
 COPY package.json pnpm-lock.yaml tsconfig.json vite.config.mts /app

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
 minimumReleaseAge: 10080


### PR DESCRIPTION
Add pnpm-workspace.yaml allowBuilds entries for `@parcel/watcher` and esbuild so that pnpm install runs their post-install build scripts instead of warning. Also COPY pnpm-workspace.yaml into the nodebuilder stage so the configuration takes effect inside the Docker build.