### PR TITLE
Use mirror.gcr.io to pull docker library image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: public.ecr.aws/docker/library/postgres:17-trixie
+    image: mirror.gcr.io/postgres:17-trixie
     restart: always
     environment:
       POSTGRES_USER: sponsorapp


### PR DESCRIPTION
To avoid pull rate limit

https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images